### PR TITLE
replace use_fixtures usage with test downloader fixture

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -134,7 +134,8 @@ disable=print-statement,
         deprecated-sys-function,
         exception-escape,
         comprehension-escape,
-        missing-docstring
+        missing-docstring,
+        redefined-outer-name
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/tests/fixtures/law_fixtures.py
+++ b/tests/fixtures/law_fixtures.py
@@ -1,6 +1,6 @@
+import typing
 from dataclasses import dataclass
 from waffle.law_url import LawUrl
-import typing
 from waffle.config import PROJECT_ROOT
 
 FIXTURES_ROOT = PROJECT_ROOT / 'tests' / 'fixtures'

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -5,16 +5,14 @@ from waffle import downloader
 
 
 @pytest.fixture
-def law_mocker() -> requests_mock.Mocker:
+def law_downloader() -> downloader.Downloader:
     with requests_mock.Mocker() as mocker:
         for fixture in law_fixtures.fixtures():
             mocker.get(str(fixture.url), text=fixture.content)
-        yield mocker
+        yield downloader.Downloader()
 
 
-@pytest.mark.usefixtures('law_mocker')
-def test_downloader() -> None:
-    download = downloader.Downloader()
-    results = list(download.legislation('english'))
+def test_downloader(law_downloader: downloader.Downloader) -> None:
+    results = list(law_downloader.legislation('english'))
     assert len(results) == 3
     assert all([result.startswith('\n<!DOCTYPE html>\n') for result in results])


### PR DESCRIPTION
Removes the ugly `use_fixtures` and replaces it with a Downloader object pre-mocked with the appropriate mock fixtures.